### PR TITLE
CMake: omit DESTINATION to install into standard destination

### DIFF
--- a/simulations/parallel/bsl_vp_3d3v_cart_dd/CMakeLists.txt
+++ b/simulations/parallel/bsl_vp_3d3v_cart_dd/CMakeLists.txt
@@ -28,7 +28,8 @@ target_link_libraries(sll_m_sim_bsl_vp_3d3v_cart_dd_slim_interface ${SLL_LIB}
                       ${SLL_EXT} ${SLL_DEPS})
 
 install(TARGETS sll_m_sim_bsl_vp_3d3v_cart_dd_slim_interface
-        DESTINATION ${INSTALL_DIR})
+	#DESTINATION ${INSTALL_DIR}
+	)
 
 # build a test that checks if the simulation's functions (exported via
 # _interface module) can be called from a C++ program cf


### PR DESCRIPTION
for installation of `sll_m_sim_bsl_vp_3d3v_cart_dd_slim_interface`.

This is an addendum to https://github.com/selalib/selalib/pull/24 -- I saw that DisCoTec's CMake could not find the interface library without this change. 

Maybe there is a smarter way of doing this?
@pnavaro I think you already realized my CMake skills are not great -- it's true! but I'm trying! ;)