### PR TITLE
checkt MPI_Fortran_INCLUDE_PATH for emptiness and case

### DIFF
--- a/src/interfaces/mpi/CMakeLists.txt
+++ b/src/interfaces/mpi/CMakeLists.txt
@@ -14,7 +14,11 @@ message(STATUS "=========================================================")
 # "/usr/local/Cellar/open-mpi/1.10.1/include;/usr/local/Cellar/open-mpi/1.10.1/lib"
 # ) set( TEST_STRING
 # "/opt/mpi/bullxmpi/1.2.8.4/include;/opt/mpi/bullxmpi/1.2.8.4/lib" )
+if("${MPI_Fortran_INCLUDE_PATH}" STREQUAL "")
+  message(FATAL_ERROR "MPI_Fortran_INCLUDE_PATH is empty")
+endif()
 set(TEST_STRING ${MPI_Fortran_INCLUDE_PATH})
+string(TOLOWER ${TEST_STRING} TEST_STRING)
 string(REGEX MATCH "open\\-?mpi|mpich|impi|bullxmpi" MPI_LIB ${TEST_STRING})
 if(MPI_LIB)
   string(REPLACE "-" "" MPI_LIB ${MPI_LIB})


### PR DESCRIPTION
- throws the correct error if the path is not set (cf. https://github.com/selalib/selalib/issues/29#issuecomment-1666457332 ) for instance because cmake has version higher than 3.9,
- and sanitizes the path if uppercase is used (e.g. "OpenMPI)